### PR TITLE
feat/image-upload

### DIFF
--- a/backend/src/api/image_upload.py
+++ b/backend/src/api/image_upload.py
@@ -1,0 +1,15 @@
+from src.models.image_upload import UploadUrlRequest, UploadUrlResponse
+from src.services.image_service import ImageService
+from fastapi import APIRouter, Depends
+from src.dependencies import get_image_service
+
+router = APIRouter()
+
+
+@router.post("/generate-upload-url", response_model=UploadUrlResponse)
+async def generateUploadUrl(
+    request: UploadUrlRequest,
+    service: ImageService = Depends(get_image_service),
+):
+    response = service.generate_upload_url(request)
+    return UploadUrlResponse(**response)

--- a/backend/src/dependencies.py
+++ b/backend/src/dependencies.py
@@ -1,4 +1,5 @@
 from src.services.notification_service import NotificationService
+from src.services.image_service import ImageService
 from src.services.poem_v3_service import PoemV3Service
 from src.services.poem_v4_service import PoemV4Service
 from functools import lru_cache
@@ -39,6 +40,11 @@ def get_ses_client():
     return boto3.client("ses", region_name="us-east-1")
 
 
+@lru_cache()
+def get_s3_client():
+    return boto3.client("s3", region_name="us-east-1")
+
+
 def get_lancedb_client():
     # db = get_db()
     # try:
@@ -51,7 +57,10 @@ def get_lancedb_client():
 @lru_cache()
 def get_poem_v4_service():
     return PoemV4Service(
-        get_openai_client(), get_datamuse_client(), get_bedrock_client()
+        get_openai_client(),
+        get_datamuse_client(),
+        get_bedrock_client(),
+        get_image_service(),
     )
 
 
@@ -65,3 +74,8 @@ def get_poem_v3_service():
 @lru_cache()
 def get_notification_service():
     return NotificationService(get_ses_client())
+
+
+@lru_cache()
+def get_image_service():
+    return ImageService(get_s3_client())

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -9,7 +9,16 @@ from mangum import Mangum
 
 load_dotenv()
 
-from src.api import root, health, poem_v1, poem_v2, poem_v3, poem_v4, contact_email
+from src.api import (
+    root,
+    health,
+    poem_v1,
+    poem_v2,
+    poem_v3,
+    poem_v4,
+    contact_email,
+    image_upload,
+)
 
 setup_logging()
 logger = logging.getLogger(__name__)
@@ -56,5 +65,6 @@ app.include_router(poem_v1.router)
 app.include_router(poem_v2.router)
 app.include_router(poem_v3.router)
 app.include_router(poem_v4.router)
+app.include_router(image_upload.router)
 
 handler = Mangum(app)

--- a/backend/src/models/common.py
+++ b/backend/src/models/common.py
@@ -2,6 +2,9 @@ from enum import Enum
 from pydantic import BaseModel
 from typing import Optional
 
+ALLOWED_MIME_TYPES = {"image/jpeg", "image/png"}
+ALLOWED_EXTENSIONS = {".jpg", ".jpeg", ".png"}
+
 
 class ReplacementType(str, Enum):
     """Enum for different types of word replacements"""

--- a/backend/src/models/image_upload.py
+++ b/backend/src/models/image_upload.py
@@ -1,0 +1,24 @@
+from pydantic import BaseModel, Field, field_validator
+from src.models.common import ALLOWED_MIME_TYPES
+
+
+class UploadUrlRequest(BaseModel):
+    fileName: str = Field(None, alias="fileName")
+    fileType: str = Field(None, alias="fileType")
+
+    class Config:
+        populate_by_name = True
+
+    @field_validator("fileType")
+    @classmethod
+    def validate_mime(cls, v):
+        if v.lower() not in ALLOWED_MIME_TYPES:
+            raise ValueError("Invalid file type. Only JPEG and PNG are allowed.")
+        return v.lower()
+
+
+class UploadUrlResponse(BaseModel):
+    """Response model for image upload URL generation"""
+
+    uploadUrl: str
+    fileKey: str

--- a/backend/src/services/image_service.py
+++ b/backend/src/services/image_service.py
@@ -1,0 +1,55 @@
+import logging
+import os
+import pathlib
+import uuid
+from src.models.common import ALLOWED_EXTENSIONS
+from src.models.image_upload import UploadUrlRequest
+from fastapi import HTTPException
+import boto3
+from botocore.exceptions import ClientError
+
+logger = logging.getLogger(__name__)
+
+
+class ImageService:
+    def __init__(self, s3_client: boto3.client):
+        self.s3_client = s3_client
+        self.bucket_name = os.getenv("S3_BUCKET_NAME")
+
+    def generate_upload_url(self, request: UploadUrlRequest):
+        file_ext = pathlib.Path(request.fileName).suffix.lower()
+        if file_ext not in ALLOWED_EXTENSIONS:
+            raise HTTPException(status_code=400, detail="Invalid file extension.")
+
+        safe_name = f"{uuid.uuid4()}{file_ext}"
+        object_key = f"uploads/{safe_name}"
+        try:
+            url = self.s3_client.generate_presigned_url(
+                "put_object",
+                Params={
+                    "Bucket": self.bucket_name,
+                    "Key": object_key,
+                    "ContentType": request.fileType,
+                    "Metadata": {"original-name": request.fileName},
+                },
+                ExpiresIn=300,  # 5 minutes
+            )
+            return {"uploadUrl": url, "fileKey": object_key}
+        except ClientError as e:
+            logger.error(e.response["Error"]["Message"])
+            raise HTTPException(status_code=500, detail=str(e))
+
+    def generate_download_url(self, object_key: str) -> str:
+        try:
+            url = self.s3_client.generate_presigned_url(
+                "get_object",
+                Params={"Bucket": self.bucket_name, "Key": object_key},
+                ExpiresIn=300,  # 5 minutes
+            )
+            return url
+        except ClientError as e:
+            logger.error(e.response["Error"]["Message"])
+            raise HTTPException(status_code=500, detail=str(e))
+
+    def delete_object(self, object_key: str):
+        self.s3_client.delete_object(Bucket=self.bucket_name, Key=object_key)

--- a/backend/src/services/poem_v4_service.py
+++ b/backend/src/services/poem_v4_service.py
@@ -22,6 +22,7 @@ import re
 import nltk
 import base64
 import logging
+from src.services.image_service import ImageService
 
 logger = logging.getLogger(__name__)
 
@@ -56,12 +57,14 @@ class PoemV4Service:
         openai_client: OpenAI,
         datamuse_client: datamuse.Datamuse,
         bedrock_client: boto3.client,
+        image_service=ImageService,
     ):
         self.init_nltk()
 
         self.openai_client = openai_client
         self.datamuse_client = datamuse_client
         self.bedrock_client = bedrock_client
+        self.image_service = image_service
         self.bucket_name = os.getenv("S3_BUCKET_NAME")
         self.table_name = os.getenv("LANCEDB_TABLE_NAME")
         logger.info(
@@ -449,8 +452,12 @@ class PoemV4Service:
         self,
         request: PoemV4CreateRequest,
     ) -> str:
+        if request.input_image_url.startswith("uploads/"):
+            imageUrl = self.image_service.generate_download_url(request.input_image_url)
+        else:
+            imageUrl = request.input_image_url
         initial_text = self.generate_initial_text(
-            request.input_image_url,
+            imageUrl,
             request.num_related_images,
             request.model,
             request.pass_image_to_model,
@@ -461,4 +468,7 @@ class PoemV4Service:
         )
         logger.debug(f"Final poem variation: {variation}")
 
+        if request.input_image_url.startswith("uploads/"):
+            logger.debug("Deleting image from s3")
+            self.image_service.delete_object(request.input_image_url)
         return variation

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,12 +9,13 @@ services:
       - ./backend/.env
     environment:
       - UV_LINK_MODE=copy
-      - AWS_PROFILE=default
+      - AWS_SHARED_CREDENTIALS_FILE=/root/.aws/credentials
+      - AWS_CONFIG_FILE=/root/.aws/config
     volumes:
       - ./backend:/app  # Hot reload
       - backend-venv:/app/.venv
       - ~/.aws:/root/.aws:ro
-    command: uv run uvicorn src.main:app --host 0.0.0.0 --port 8000 --reload
+    command: uvicorn src.main:app --host 0.0.0.0 --port 8000 --reload
 
   frontend:
     build:

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -4,7 +4,7 @@
  * FastAPI
  * OpenAPI spec version: 0.1.0
  */
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery } from "@tanstack/react-query";
 import type {
   DataTag,
   DefinedInitialDataOptions,
@@ -18,9 +18,9 @@ import type {
   UseMutationResult,
   UseQueryOptions,
   UseQueryResult,
-} from '@tanstack/react-query';
+} from "@tanstack/react-query";
 
-import { customAxiosInstance } from './api-client';
+import { customAxiosInstance } from "./api-client";
 export interface ContactEmailCreateRequest {
   senderName?: string;
   senderAddress?: string;
@@ -46,13 +46,13 @@ export type LLMName = (typeof LLMName)[keyof typeof LLMName];
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const LLMName = {
-  'deepseek-r1': 'deepseek-r1',
-  'claude-opus-4_1': 'claude-opus-4_1',
-  'claude-opus-4': 'claude-opus-4',
-  'claude-sonnet-4': 'claude-sonnet-4',
-  'gpt-41-nano': 'gpt-4.1-nano',
-  'gpt-5-mini': 'gpt-5-mini',
-  'gpt-51': 'gpt-5.1',
+  "deepseek-r1": "deepseek-r1",
+  "claude-opus-4_1": "claude-opus-4_1",
+  "claude-opus-4": "claude-opus-4",
+  "claude-sonnet-4": "claude-sonnet-4",
+  "gpt-41-nano": "gpt-4.1-nano",
+  "gpt-5-mini": "gpt-5-mini",
+  "gpt-51": "gpt-5.1",
 } as const;
 
 /**
@@ -138,6 +138,19 @@ export interface ReplacementTypeCounts {
   homophone?: ReplacementTypeCountsHomophone;
 }
 
+export interface UploadUrlRequest {
+  fileName?: string;
+  fileType?: string;
+}
+
+/**
+ * Response model for image upload URL generation
+ */
+export interface UploadUrlResponse {
+  uploadUrl: string;
+  fileKey: string;
+}
+
 export type ValidationErrorLocItem = string | number;
 
 export interface ValidationError {
@@ -150,7 +163,7 @@ export interface ValidationError {
  * @summary Api Info
  */
 export const apiInfoInfoGet = (signal?: AbortSignal) => {
-  return customAxiosInstance<unknown>({ url: `/info`, method: 'GET', signal });
+  return customAxiosInstance<unknown>({ url: `/info`, method: "GET", signal });
 };
 
 export const getApiInfoInfoGetQueryKey = () => {
@@ -199,10 +212,10 @@ export function useApiInfoInfoGet<
           TError,
           Awaited<ReturnType<typeof apiInfoInfoGet>>
         >,
-        'initialData'
+        "initialData"
       >;
   },
-  queryClient?: QueryClient
+  queryClient?: QueryClient,
 ): DefinedUseQueryResult<TData, TError> & {
   queryKey: DataTag<QueryKey, TData, TError>;
 };
@@ -220,10 +233,10 @@ export function useApiInfoInfoGet<
           TError,
           Awaited<ReturnType<typeof apiInfoInfoGet>>
         >,
-        'initialData'
+        "initialData"
       >;
   },
-  queryClient?: QueryClient
+  queryClient?: QueryClient,
 ): UseQueryResult<TData, TError> & {
   queryKey: DataTag<QueryKey, TData, TError>;
 };
@@ -236,7 +249,7 @@ export function useApiInfoInfoGet<
       UseQueryOptions<Awaited<ReturnType<typeof apiInfoInfoGet>>, TError, TData>
     >;
   },
-  queryClient?: QueryClient
+  queryClient?: QueryClient,
 ): UseQueryResult<TData, TError> & {
   queryKey: DataTag<QueryKey, TData, TError>;
 };
@@ -253,7 +266,7 @@ export function useApiInfoInfoGet<
       UseQueryOptions<Awaited<ReturnType<typeof apiInfoInfoGet>>, TError, TData>
     >;
   },
-  queryClient?: QueryClient
+  queryClient?: QueryClient,
 ): UseQueryResult<TData, TError> & {
   queryKey: DataTag<QueryKey, TData, TError>;
 } {
@@ -274,12 +287,12 @@ export function useApiInfoInfoGet<
  */
 export const sendContactEmailSendContactEmailPost = (
   contactEmailCreateRequest: ContactEmailCreateRequest,
-  signal?: AbortSignal
+  signal?: AbortSignal,
 ) => {
   return customAxiosInstance<ContactEmailResponse>({
     url: `/send-contact-email`,
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
     data: contactEmailCreateRequest,
     signal,
   });
@@ -301,10 +314,10 @@ export const getSendContactEmailSendContactEmailPostMutationOptions = <
   { data: ContactEmailCreateRequest },
   TContext
 > => {
-  const mutationKey = ['sendContactEmailSendContactEmailPost'];
+  const mutationKey = ["sendContactEmailSendContactEmailPost"];
   const { mutation: mutationOptions } = options
     ? options.mutation &&
-      'mutationKey' in options.mutation &&
+      "mutationKey" in options.mutation &&
       options.mutation.mutationKey
       ? options
       : { ...options, mutation: { ...options.mutation, mutationKey } }
@@ -345,7 +358,7 @@ export const useSendContactEmailSendContactEmailPost = <
       TContext
     >;
   },
-  queryClient?: QueryClient
+  queryClient?: QueryClient,
 ): UseMutationResult<
   Awaited<ReturnType<typeof sendContactEmailSendContactEmailPost>>,
   TError,
@@ -365,7 +378,7 @@ export const useSendContactEmailSendContactEmailPost = <
 export const healthCheckHealthGet = (signal?: AbortSignal) => {
   return customAxiosInstance<unknown>({
     url: `/health`,
-    method: 'GET',
+    method: "GET",
     signal,
   });
 };
@@ -424,10 +437,10 @@ export function useHealthCheckHealthGet<
           TError,
           Awaited<ReturnType<typeof healthCheckHealthGet>>
         >,
-        'initialData'
+        "initialData"
       >;
   },
-  queryClient?: QueryClient
+  queryClient?: QueryClient,
 ): DefinedUseQueryResult<TData, TError> & {
   queryKey: DataTag<QueryKey, TData, TError>;
 };
@@ -449,10 +462,10 @@ export function useHealthCheckHealthGet<
           TError,
           Awaited<ReturnType<typeof healthCheckHealthGet>>
         >,
-        'initialData'
+        "initialData"
       >;
   },
-  queryClient?: QueryClient
+  queryClient?: QueryClient,
 ): UseQueryResult<TData, TError> & {
   queryKey: DataTag<QueryKey, TData, TError>;
 };
@@ -469,7 +482,7 @@ export function useHealthCheckHealthGet<
       >
     >;
   },
-  queryClient?: QueryClient
+  queryClient?: QueryClient,
 ): UseQueryResult<TData, TError> & {
   queryKey: DataTag<QueryKey, TData, TError>;
 };
@@ -490,7 +503,7 @@ export function useHealthCheckHealthGet<
       >
     >;
   },
-  queryClient?: QueryClient
+  queryClient?: QueryClient,
 ): UseQueryResult<TData, TError> & {
   queryKey: DataTag<QueryKey, TData, TError>;
 } {
@@ -513,7 +526,7 @@ export function useHealthCheckHealthGet<
 export const detailedHealthCheckHealthDetailedGet = (signal?: AbortSignal) => {
   return customAxiosInstance<unknown>({
     url: `/health/detailed`,
-    method: 'GET',
+    method: "GET",
     signal,
   });
 };
@@ -573,10 +586,10 @@ export function useDetailedHealthCheckHealthDetailedGet<
           TError,
           Awaited<ReturnType<typeof detailedHealthCheckHealthDetailedGet>>
         >,
-        'initialData'
+        "initialData"
       >;
   },
-  queryClient?: QueryClient
+  queryClient?: QueryClient,
 ): DefinedUseQueryResult<TData, TError> & {
   queryKey: DataTag<QueryKey, TData, TError>;
 };
@@ -598,10 +611,10 @@ export function useDetailedHealthCheckHealthDetailedGet<
           TError,
           Awaited<ReturnType<typeof detailedHealthCheckHealthDetailedGet>>
         >,
-        'initialData'
+        "initialData"
       >;
   },
-  queryClient?: QueryClient
+  queryClient?: QueryClient,
 ): UseQueryResult<TData, TError> & {
   queryKey: DataTag<QueryKey, TData, TError>;
 };
@@ -618,7 +631,7 @@ export function useDetailedHealthCheckHealthDetailedGet<
       >
     >;
   },
-  queryClient?: QueryClient
+  queryClient?: QueryClient,
 ): UseQueryResult<TData, TError> & {
   queryKey: DataTag<QueryKey, TData, TError>;
 };
@@ -639,7 +652,7 @@ export function useDetailedHealthCheckHealthDetailedGet<
       >
     >;
   },
-  queryClient?: QueryClient
+  queryClient?: QueryClient,
 ): UseQueryResult<TData, TError> & {
   queryKey: DataTag<QueryKey, TData, TError>;
 } {
@@ -661,12 +674,12 @@ export function useDetailedHealthCheckHealthDetailedGet<
  */
 export const generatePoemV1GeneratePoemV1Post = (
   poemV1CreateRequest: PoemV1CreateRequest,
-  signal?: AbortSignal
+  signal?: AbortSignal,
 ) => {
   return customAxiosInstance<PoemResponse>({
     url: `/generate-poem-v1`,
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
     data: poemV1CreateRequest,
     signal,
   });
@@ -688,10 +701,10 @@ export const getGeneratePoemV1GeneratePoemV1PostMutationOptions = <
   { data: PoemV1CreateRequest },
   TContext
 > => {
-  const mutationKey = ['generatePoemV1GeneratePoemV1Post'];
+  const mutationKey = ["generatePoemV1GeneratePoemV1Post"];
   const { mutation: mutationOptions } = options
     ? options.mutation &&
-      'mutationKey' in options.mutation &&
+      "mutationKey" in options.mutation &&
       options.mutation.mutationKey
       ? options
       : { ...options, mutation: { ...options.mutation, mutationKey } }
@@ -730,7 +743,7 @@ export const useGeneratePoemV1GeneratePoemV1Post = <
       TContext
     >;
   },
-  queryClient?: QueryClient
+  queryClient?: QueryClient,
 ): UseMutationResult<
   Awaited<ReturnType<typeof generatePoemV1GeneratePoemV1Post>>,
   TError,
@@ -748,12 +761,12 @@ export const useGeneratePoemV1GeneratePoemV1Post = <
  */
 export const generatePoemV2GeneratePoemV2Post = (
   poemV2CreateRequest: PoemV2CreateRequest,
-  signal?: AbortSignal
+  signal?: AbortSignal,
 ) => {
   return customAxiosInstance<PoemResponse>({
     url: `/generate-poem-v2`,
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
     data: poemV2CreateRequest,
     signal,
   });
@@ -775,10 +788,10 @@ export const getGeneratePoemV2GeneratePoemV2PostMutationOptions = <
   { data: PoemV2CreateRequest },
   TContext
 > => {
-  const mutationKey = ['generatePoemV2GeneratePoemV2Post'];
+  const mutationKey = ["generatePoemV2GeneratePoemV2Post"];
   const { mutation: mutationOptions } = options
     ? options.mutation &&
-      'mutationKey' in options.mutation &&
+      "mutationKey" in options.mutation &&
       options.mutation.mutationKey
       ? options
       : { ...options, mutation: { ...options.mutation, mutationKey } }
@@ -817,7 +830,7 @@ export const useGeneratePoemV2GeneratePoemV2Post = <
       TContext
     >;
   },
-  queryClient?: QueryClient
+  queryClient?: QueryClient,
 ): UseMutationResult<
   Awaited<ReturnType<typeof generatePoemV2GeneratePoemV2Post>>,
   TError,
@@ -835,12 +848,12 @@ export const useGeneratePoemV2GeneratePoemV2Post = <
  */
 export const generatePoemV3GeneratePoemV3Post = (
   poemV3CreateRequest: PoemV3CreateRequest,
-  signal?: AbortSignal
+  signal?: AbortSignal,
 ) => {
   return customAxiosInstance<PoemResponse>({
     url: `/generate-poem-v3`,
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
     data: poemV3CreateRequest,
     signal,
   });
@@ -862,10 +875,10 @@ export const getGeneratePoemV3GeneratePoemV3PostMutationOptions = <
   { data: PoemV3CreateRequest },
   TContext
 > => {
-  const mutationKey = ['generatePoemV3GeneratePoemV3Post'];
+  const mutationKey = ["generatePoemV3GeneratePoemV3Post"];
   const { mutation: mutationOptions } = options
     ? options.mutation &&
-      'mutationKey' in options.mutation &&
+      "mutationKey" in options.mutation &&
       options.mutation.mutationKey
       ? options
       : { ...options, mutation: { ...options.mutation, mutationKey } }
@@ -904,7 +917,7 @@ export const useGeneratePoemV3GeneratePoemV3Post = <
       TContext
     >;
   },
-  queryClient?: QueryClient
+  queryClient?: QueryClient,
 ): UseMutationResult<
   Awaited<ReturnType<typeof generatePoemV3GeneratePoemV3Post>>,
   TError,
@@ -922,12 +935,12 @@ export const useGeneratePoemV3GeneratePoemV3Post = <
  */
 export const generatePoemV4GeneratePoemV4Post = (
   poemV4CreateRequest: PoemV4CreateRequest,
-  signal?: AbortSignal
+  signal?: AbortSignal,
 ) => {
   return customAxiosInstance<PoemResponse>({
     url: `/generate-poem-v4`,
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
     data: poemV4CreateRequest,
     signal,
   });
@@ -949,10 +962,10 @@ export const getGeneratePoemV4GeneratePoemV4PostMutationOptions = <
   { data: PoemV4CreateRequest },
   TContext
 > => {
-  const mutationKey = ['generatePoemV4GeneratePoemV4Post'];
+  const mutationKey = ["generatePoemV4GeneratePoemV4Post"];
   const { mutation: mutationOptions } = options
     ? options.mutation &&
-      'mutationKey' in options.mutation &&
+      "mutationKey" in options.mutation &&
       options.mutation.mutationKey
       ? options
       : { ...options, mutation: { ...options.mutation, mutationKey } }
@@ -991,7 +1004,7 @@ export const useGeneratePoemV4GeneratePoemV4Post = <
       TContext
     >;
   },
-  queryClient?: QueryClient
+  queryClient?: QueryClient,
 ): UseMutationResult<
   Awaited<ReturnType<typeof generatePoemV4GeneratePoemV4Post>>,
   TError,
@@ -1000,6 +1013,95 @@ export const useGeneratePoemV4GeneratePoemV4Post = <
 > => {
   const mutationOptions =
     getGeneratePoemV4GeneratePoemV4PostMutationOptions(options);
+
+  return useMutation(mutationOptions, queryClient);
+};
+
+/**
+ * @summary Generateuploadurl
+ */
+export const generateUploadUrlGenerateUploadUrlPost = (
+  uploadUrlRequest: UploadUrlRequest,
+  signal?: AbortSignal,
+) => {
+  return customAxiosInstance<UploadUrlResponse>({
+    url: `/generate-upload-url`,
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    data: uploadUrlRequest,
+    signal,
+  });
+};
+
+export const getGenerateUploadUrlGenerateUploadUrlPostMutationOptions = <
+  TError = HTTPValidationError,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof generateUploadUrlGenerateUploadUrlPost>>,
+    TError,
+    { data: UploadUrlRequest },
+    TContext
+  >;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof generateUploadUrlGenerateUploadUrlPost>>,
+  TError,
+  { data: UploadUrlRequest },
+  TContext
+> => {
+  const mutationKey = ["generateUploadUrlGenerateUploadUrlPost"];
+  const { mutation: mutationOptions } = options
+    ? options.mutation &&
+      "mutationKey" in options.mutation &&
+      options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey } };
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof generateUploadUrlGenerateUploadUrlPost>>,
+    { data: UploadUrlRequest }
+  > = (props) => {
+    const { data } = props ?? {};
+
+    return generateUploadUrlGenerateUploadUrlPost(data);
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type GenerateUploadUrlGenerateUploadUrlPostMutationResult = NonNullable<
+  Awaited<ReturnType<typeof generateUploadUrlGenerateUploadUrlPost>>
+>;
+export type GenerateUploadUrlGenerateUploadUrlPostMutationBody =
+  UploadUrlRequest;
+export type GenerateUploadUrlGenerateUploadUrlPostMutationError =
+  HTTPValidationError;
+
+/**
+ * @summary Generateuploadurl
+ */
+export const useGenerateUploadUrlGenerateUploadUrlPost = <
+  TError = HTTPValidationError,
+  TContext = unknown,
+>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof generateUploadUrlGenerateUploadUrlPost>>,
+      TError,
+      { data: UploadUrlRequest },
+      TContext
+    >;
+  },
+  queryClient?: QueryClient,
+): UseMutationResult<
+  Awaited<ReturnType<typeof generateUploadUrlGenerateUploadUrlPost>>,
+  TError,
+  { data: UploadUrlRequest },
+  TContext
+> => {
+  const mutationOptions =
+    getGenerateUploadUrlGenerateUploadUrlPostMutationOptions(options);
 
   return useMutation(mutationOptions, queryClient);
 };

--- a/frontend/src/components/home-page/versions/version-4.tsx
+++ b/frontend/src/components/home-page/versions/version-4.tsx
@@ -1,12 +1,15 @@
 import { Link } from 'react-router';
 import { Path } from '../../../router/path';
 import Version from '../version';
-import { useState, Fragment } from 'react';
+import { useState, Fragment, type ChangeEvent } from 'react';
 import {
   LLMName,
   useGeneratePoemV4GeneratePoemV4Post,
+  useGenerateUploadUrlGenerateUploadUrlPost,
   type PoemResponse,
   type PoemV4CreateRequest,
+  type UploadUrlRequest,
+  type UploadUrlResponse,
 } from '../../../api';
 
 type ModelOption = { label: string; value: string };
@@ -23,7 +26,7 @@ const MODEL_LABELS: Record<(typeof LLMName)[keyof typeof LLMName], string> = {
 
 /** build strongly-typed options from the LLMName const */
 const llmValues = Object.values(
-  LLMName
+  LLMName,
 ) as (typeof LLMName)[keyof typeof LLMName][];
 const modelOptions: ModelOption[] = llmValues.map((v) => ({
   label: MODEL_LABELS[v] ?? v,
@@ -38,6 +41,8 @@ type Replacement = {
   rel_cns: number;
   rel_hom: number;
 };
+
+type InputType = 'url' | 'image';
 
 const Version4 = () => {
   const [imageUrl, setImageUrl] = useState<string>('');
@@ -56,32 +61,21 @@ const Version4 = () => {
   const [passImageToModel, setPassImageToModel] = useState<boolean>(false);
   const [numRelatedImages, setNumRelatedImages] = useState<number>(3);
   const [detailsOpen, setDetailsOpen] = useState(false);
+  const [inputType, setInputType] = useState<InputType>('url');
+  const [file, setFile] = useState<File | null>(null);
 
   const { mutate } = useGeneratePoemV4GeneratePoemV4Post();
+  const { mutate: mutateUploadUrl } =
+    useGenerateUploadUrlGenerateUploadUrlPost();
 
   const updateReplacement = (key: keyof Replacement, value: number) => {
     setReplacement((prev) => ({ ...prev, [key]: value }));
   };
 
-  const callApi = async (event?: React.MouseEvent<HTMLButtonElement>) => {
-    event?.preventDefault();
-    setLoading(true);
-    setPoem([]);
-
-    const values = Object.values(replacement);
-    const total = values.reduce((a, b) => a + b, 0);
-
-    // If all zeros, default synonyms to 1
-    if (!values.some((r) => r)) {
-      setReplacement((prev) => ({ ...prev, ml: 1 }));
-    } else if (total > 60) {
-      setTooManyVars(true);
-      setLoading(false);
-      return;
-    }
-
+  const generateVariation = async (curImageUrl: string) => {
+    console.log('generating poem');
     const body: PoemV4CreateRequest = {
-      inputImageUrl: imageUrl,
+      inputImageUrl: curImageUrl,
       replacementTypeCounts: {
         means_like: replacement.ml,
         triggered_by: replacement.rel_trg,
@@ -107,8 +101,53 @@ const Version4 = () => {
         onSettled: () => {
           setLoading(false);
         },
-      }
+      },
     );
+  };
+
+  const callApi = async (event?: React.MouseEvent<HTMLButtonElement>) => {
+    event?.preventDefault();
+    setLoading(true);
+    setPoem([]);
+
+    const values = Object.values(replacement);
+    const total = values.reduce((a, b) => a + b, 0);
+
+    // If all zeros, default synonyms to 1
+    if (!values.some((r) => r)) {
+      setReplacement((prev) => ({ ...prev, ml: 1 }));
+    } else if (total > 60) {
+      setTooManyVars(true);
+      setLoading(false);
+      return;
+    }
+
+    if (file) {
+      mutateUploadUrl(
+        {
+          data: {
+            fileName: file?.name,
+            fileType: file?.type,
+          } as UploadUrlRequest,
+        },
+        {
+          onSuccess: async (response: UploadUrlResponse) => {
+            console.log('uploading image');
+            fetch(response.uploadUrl, {
+              method: 'PUT',
+              body: file,
+              headers: { 'Content-Type': file?.type }, // Must match the type used during URL generation
+            }).then(() => generateVariation(response.fileKey));
+          },
+          onError: (error: any) => {
+            console.error('API error:', error);
+            setLoading(false);
+          },
+        },
+      );
+    } else {
+      generateVariation(imageUrl);
+    }
   };
 
   const generateWordsList = (poemVariation?: string): string[] => {
@@ -131,6 +170,37 @@ const Version4 = () => {
     return match?.[1];
   };
 
+  const handleRadioChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setInputType(e.target.value as InputType);
+    // reset other inputs when switching types
+    setImageUrl('');
+    setFile(null);
+  };
+
+  const onImageChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files && e.target.files[0] ? e.target.files[0] : null;
+
+    if (!file) {
+      alert('No file selected!');
+      return;
+    }
+
+    // Basic validation for image file types
+    const allowedExtensions = /(\.jpg|\.jpeg|\.png)$/i;
+    if (!allowedExtensions.exec(file.name ?? '')) {
+      alert('Please upload an image file.');
+      return;
+    }
+
+    // Check size (e.g., limit to 5MB)
+    if (file.size > 10 * 1024 * 1024) {
+      alert('File is too large!');
+      return;
+    }
+
+    setFile(file);
+  };
+
   return (
     <Version versionName="Version 4">
       <div>
@@ -139,22 +209,65 @@ const Version4 = () => {
           that poem through Version 3 of our algorithm. To learn more, visit our{' '}
           <Link to={Path.Overview}>Project Overview Page</Link>.
         </p>
-        <p>
-          For example, try:{' '}
-          <a
-            className="link"
-            href="https://live.staticflickr.com/65535/54638556216_146f8ac2b6_k.jpg"
-          >
-            https://live.staticflickr.com/65535/54638556216_146f8ac2b6_k.jpg
-          </a>
-        </p>
-        <input
-          type="text"
-          placeholder="Enter Image URL"
-          className="input"
-          value={imageUrl}
-          onChange={(e) => setImageUrl(e.target.value)}
-        />
+
+        <div>
+          <span className="text-violet-500 text-2xl">Image Input</span>
+        </div>
+
+        <div className="flex flex-row gap-4 mb-2">
+          <label className="cursor-pointer">
+            <input
+              type="radio"
+              name="image-input-type"
+              value="url"
+              checked={inputType === 'url'}
+              onChange={handleRadioChange}
+            />{' '}
+            URL
+          </label>
+
+          <label className="cursor-pointer">
+            <input
+              type="radio"
+              name="image-input-type"
+              value="image"
+              checked={inputType === 'image'}
+              onChange={handleRadioChange}
+            />{' '}
+            Image Upload
+          </label>
+        </div>
+
+        {inputType === 'url' ? (
+          <>
+            <p>
+              For example, try:{' '}
+              <a
+                className="link"
+                href="https://live.staticflickr.com/65535/54638556216_146f8ac2b6_k.jpg"
+              >
+                https://live.staticflickr.com/65535/54638556216_146f8ac2b6_k.jpg
+              </a>
+            </p>
+            <input
+              type="text"
+              placeholder="Enter Image URL"
+              className="input"
+              value={imageUrl}
+              onChange={(e) => setImageUrl(e.target.value)}
+            />
+          </>
+        ) : (
+          <>
+            <p>Select an image to upload.</p>
+            <input
+              type="file"
+              accept="image/*"
+              className="file-input file-input-bordered file-input-sm w-full"
+              onChange={onImageChange}
+            />
+          </>
+        )}
 
         <details
           className="w-full mb-2"
@@ -199,7 +312,7 @@ const Version4 = () => {
                 onChange={(e) => {
                   const n = parseInt(e.target.value, 10);
                   setNumRelatedImages(
-                    Number.isNaN(n) ? 1 : Math.max(1, Math.min(10, n))
+                    Number.isNaN(n) ? 1 : Math.max(1, Math.min(10, n)),
                   );
                 }}
                 className="input focus:outline-primary input-bordered input-xs w-12"


### PR DESCRIPTION
# Add image upload functionality
This PR enables users to upload images to use when generating a version 4 poem.

## Frontend
- Add image type selector (url vs file)
- For image uploads, upon clicking generate, fetch presigned url & upload file to it, before using the filekey for the imageUrl in the generate-variation request

## Backend
- Add /generate-upload-url endpoint to generate presigned image url
- Create image service to use s3 client to get presigned url for image uploads, get presigned url for image downloads, and delete image object
- Update poem 4 service to be able to optionally use the images uploaded to s3